### PR TITLE
Add use_maintenance_policy parameter

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,7 @@ upgrade_timeout: 1200
 cluster_name: Default
 check_upgrade: false
 reboot_after_upgrade: true
+use_maintenance_policy: true
 host_statuses:
   - up
 host_names:

--- a/tasks/cluster_policy.yml
+++ b/tasks/cluster_policy.yml
@@ -1,0 +1,32 @@
+- name: Get cluster facts
+  ovirt_clusters_facts:
+    auth: "{{ ovirt_auth }}"
+    pattern: "name={{ cluster_name }}"
+  check_mode: "no"
+
+- name: Get name of the original scheduling policy
+  ovirt_scheduling_policies_facts:
+    auth: "{{ ovirt_auth }}"
+    id: "{{ ovirt_clusters[0].scheduling_policy.id }}"
+  check_mode: "no"
+
+- name: Remember the cluster scheduling policy
+  set_fact:
+    cluster_scheduling_policy: "{{ ovirt_scheduling_policies[0].name }}"
+
+- name: Get API facts
+  # TODO: Change when Ansible 2.5 is released:
+  # ovirt_api_facts:
+  ovirt_api_facts_internal_25:
+    auth: "{{ ovirt_auth }}"
+  check_mode: "no"
+
+- name: Set in cluster upgrade policy
+  ovirt_clusters:
+    auth: "{{ ovirt_auth }}"
+    name: "{{ cluster_name }}"
+    scheduling_policy: cluster_maintenance
+  register: cluster_policy
+  when:
+    - (ovirt_api.product_info.version.major >= 4 and ovirt_api.product_info.version.major >= 2) or
+      (ovirt_api.product_info.version.major == 4 and ovirt_api.product_info.version.major == 1 and ovirt_api.product_info.version.revision >= 4)

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -31,44 +31,14 @@
       when: ovirt_hosts | length == 0
 
     - block:
-        - name: Get cluster facts
-          ovirt_clusters_facts:
-            auth: "{{ ovirt_auth }}"
-            pattern: "name={{ cluster_name }}"
-          check_mode: "no"
-
-        - name: Get name of the original scheduling policy
-          ovirt_scheduling_policies_facts:
-            auth: "{{ ovirt_auth }}"
-            id: "{{ ovirt_clusters[0].scheduling_policy.id }}"
-          check_mode: "no"
-
-        - name: Remember the cluster scheduling policy
-          set_fact:
-            cluster_scheduling_policy: "{{ ovirt_scheduling_policies[0].name }}"
+        - include: cluster_policy.yml
+          when: use_maintenance_policy
 
         - name: Get list of VMs in cluster
           ovirt_vms_facts:
             auth: "{{ ovirt_auth }}"
             pattern: "cluster={{ cluster_name }}"
           check_mode: "no"
-
-        - name: Get API facts
-          # TODO: Change when Ansible 2.5 is released:
-          # ovirt_api_facts:
-          ovirt_api_facts_internal_25:
-            auth: "{{ ovirt_auth }}"
-          check_mode: "no"
-
-        - name: Set in cluster upgrade policy
-          ovirt_clusters:
-            auth: "{{ ovirt_auth }}"
-            name: "{{ cluster_name }}"
-            scheduling_policy: cluster_maintenance
-          register: cluster_policy
-          when:
-            - (ovirt_api.product_info.version.major >= 4 and ovirt_api.product_info.version.major >= 2) or
-              (ovirt_api.product_info.version.major == 4 and ovirt_api.product_info.version.major == 1 and ovirt_api.product_info.version.revision >= 4)
 
         - name: Shutdown VMs which can be stopped
           ovirt_vms:
@@ -104,7 +74,7 @@
             auth: "{{ ovirt_auth }}"
             name: "{{ cluster_name }}"
             scheduling_policy: "{{ cluster_scheduling_policy }}"
-          when: cluster_policy.changed | default(false)
+          when: use_maintenance_policy and cluster_policy.changed | default(false)
 
         - name: Start again stopped VMs
           ovirt_vms:


### PR DESCRIPTION
This patch add new use_maintenance_policy parameter to handle if the
cluster policy should be switched to cluster_maintenance during upgrade
or if the policy should be unchanged.

Change-Id: I0ec567283282575d0e90bd00a96de5172db0dde9
Bug-Url: https://bugzilla.redhat.com/show_bug.cgi?id=1539761
Signed-off-by: Ondra Machacek <omachace@redhat.com>