### PR TITLE
Fix issue in starting the stopped VMs

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -72,6 +72,7 @@
           ovirt_vms:
             auth: "{{ ovirt_auth }}"
             name: "{{ item }}"
+            state: running
           ignore_errors: "yes"
           with_items:
             - "{{ stopped_vms | default([]) }}"
@@ -80,6 +81,7 @@
           ovirt_vms:
             auth: "{{ ovirt_auth }}"
             name: "{{ item }}"
+            state: running
           ignore_errors: "yes"
           with_items:
             - "{{ pinned_vms_names | default([]) }}"


### PR DESCRIPTION
The task to start the VMs doesn't have a "state" parameter. By default,
the state is "present" for ovirt_vm module and hence the VM will not
get started if we didn't pass the "state" parameter.