### PR TITLE
Remember scheduling policy properties

### DIFF
--- a/tasks/cluster_policy.yml
+++ b/tasks/cluster_policy.yml
@@ -14,6 +14,10 @@
   set_fact:
     cluster_scheduling_policy: "{{ ovirt_scheduling_policies[0].name }}"
 
+- name: Remember the cluster scheduling policy properties
+  set_fact:
+    cluster_scheduling_policy_properties: "{{ ovirt_clusters[0].custom_scheduling_policy_properties }}"
+
 - name: Get API facts
   ovirt_api_facts:
     auth: "{{ ovirt_auth }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -66,6 +66,7 @@
             auth: "{{ ovirt_auth }}"
             name: "{{ cluster_name }}"
             scheduling_policy: "{{ cluster_scheduling_policy }}"
+            scheduling_policy_properties: "{{ cluster_scheduling_policy_properties }}"
           when: use_maintenance_policy and cluster_policy.changed | default(false)
 
         - name: Start again stopped VMs


### PR DESCRIPTION
Previously when we changed the scheduling policy to cluster-maintanence
we didn't remember the preivous policy properties. This patch add a
variable to remember the policy properties and properly restore them.

Change-Id: I90b0f85c06ebffe4303f39542b7ae772cb1ff682
Bug-url: https://bugzilla.redhat.com/show_bug.cgi?id=1632257
Signed-off-by: Ondra Machacek <omachace@redhat.com>