### PR TITLE
Skip ovirt_auth logout if the engine_token matches the ovirt_auth token

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,6 +4,7 @@
 ## this workarounds it until Ansible resolves the issue:
 - set_fact:
     stop_non_migratable_vms: "{{ stop_non_migratable_vms }}"
+    provided_token: "{{ engine_token | default(lookup('env','OVIRT_TOKEN')) | default('') }}"
 
 - block:
     - name: Login to oVirt
@@ -16,7 +17,7 @@
         token: "{{ engine_token | default(lookup('env','OVIRT_TOKEN')) | default(omit) }}"
         insecure: "{{ engine_insecure | default(true) }}"
       when: ovirt_auth is undefined or not ovirt_auth
-      register: loggedin
+      register: login_result
       tags:
         - always
 
@@ -93,6 +94,8 @@
       ovirt_auth:
         state: absent
         ovirt_auth: "{{ ovirt_auth }}"
-      when: not loggedin.skipped | default(false)
+      when:
+        - login_result.skipped is defined and not login_result.skipped
+        - provided_token != ovirt_auth.token
       tags:
         - always


### PR DESCRIPTION
In ovirt webadmin, the AnsibleServlet passes the SSO token for the
logged in user.  This role would logout the token upon completion
causing the user to also be logged out of the webadmin UI.  The
logout skip condition now avoids logging out an existing token.

In the case that engine_token is provided, it is reused in ovirt_auth's
output.  By skipping the logout, the token will remain valid for use by
other SSO apps.  Using `login_result.changed` won't work since ovirt_auth
doesn't set it true (the module doesn't "change" anything).