### PR TITLE
FIX: correct undefined variable ovirt_clusters

### DIFF
--- a/tasks/cluster_policy.yml
+++ b/tasks/cluster_policy.yml
@@ -11,7 +11,7 @@
 
 - name: Remember the cluster scheduling policy properties
   set_fact:
-    cluster_scheduling_policy_properties: "{{ ovirt_clusters[0].custom_scheduling_policy_properties }}"
+    cluster_scheduling_policy_properties: "{{ cluster_info.ovirt_clusters[0].custom_scheduling_policy_properties }}"
 
 - name: Set in cluster upgrade policy
   ovirt_cluster:


### PR DESCRIPTION
The role failed because `ovirt_clusters` was not defined. 
