### PR TITLE
add job to informa that upgrade failed

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -147,6 +147,12 @@
             severity: error
             cluster: "{{ cluster_info.ovirt_clusters[0].id }}"
 
+        - name: Update job failed
+          ovirt_job:
+            auth: "{{ ovirt_auth }}"
+            description: "Upgrading hosts"
+            state: failed
+
       always:
         - name: Set original cluster policy
           ovirt_cluster:


### PR DESCRIPTION
Previously it did not inform that the upgrade failed. Now you can see it in events and in tasks.

@mwperina 