### PR TITLE
Correct extra_vars from engine

### DIFF
--- a/tasks/cluster_policy.yml
+++ b/tasks/cluster_policy.yml
@@ -16,7 +16,7 @@
 - name: Set in cluster upgrade policy
   ovirt_cluster:
     auth: "{{ ovirt_auth }}"
-    name: "{{ cluster_name }}"
+    name: "{{ cluster_name | regex_replace('\"','') }}"
     scheduling_policy: cluster_maintenance
   register: cluster_policy
   when:

--- a/tasks/cluster_policy.yml
+++ b/tasks/cluster_policy.yml
@@ -16,7 +16,7 @@
 - name: Set in cluster upgrade policy
   ovirt_cluster:
     auth: "{{ ovirt_auth }}"
-    name: "{{ cluster_name | regex_replace('\"','') }}"
+    name: "{{ cluster_name }}"
     scheduling_policy: cluster_maintenance
   register: cluster_policy
   when:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -71,7 +71,7 @@
     - name: Get hosts
       ovirt_host_info:
         auth: "{{ ovirt_auth }}"
-        pattern: "cluster={{ cluster_name | regex_replace('\"','') | mandatory }} {{ check_upgrade | ternary('', 'update_available=true') }} {{ host_names_extra | default(host_names) | map('regex_replace','\"', '') | list | map('regex_replace', '^(.*)$', 'name=\\1') | list | join(' or ') }} {{ host_statuses | map('regex_replace', '^(.*)$', 'status=\\1') | list | join(' or ') }}"
+        pattern: "cluster={{ cluster_name | mandatory }} {{ check_upgrade | ternary('', 'update_available=true') }} {{ host_names_extra | default(host_names) | map('regex_replace','\"', '') | list | map('regex_replace', '^(.*)$', 'name=\\1') | list | join(' or ') }} {{ host_statuses | map('regex_replace', '^(.*)$', 'status=\\1') | list | join(' or ') }}"
       check_mode: "no"
       register: host_info
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -61,10 +61,17 @@
         severity: normal
         cluster: "{{ cluster_info.ovirt_clusters[0].id }}"
 
+    # This task converts string host_names to list.
+    # Here must be another variable because engine sends host_names as extra vars and it has bigger priority and cannot be overwritten.
+    - name: Check host_names type
+      set_fact:
+        host_names_extra: "{{ host_names | regex_replace('([)|(])', '') }}"
+      when: host_names | type_debug != 'list'
+
     - name: Get hosts
       ovirt_host_info:
         auth: "{{ ovirt_auth }}"
-        pattern: "cluster={{ cluster_name | mandatory }} {{ check_upgrade | ternary('', 'update_available=true') }} {{ host_names | map('regex_replace', '^(.*)$', 'name=\\1') | list | join(' or ') }} {{ host_statuses | map('regex_replace', '^(.*)$', 'status=\\1') | list | join(' or ') }}"
+        pattern: "cluster={{ cluster_name | regex_replace('\"','') | mandatory }} {{ check_upgrade | ternary('', 'update_available=true') }} {{ host_names_extra | default(host_names) | map('regex_replace','\"', '') | list | map('regex_replace', '^(.*)$', 'name=\\1') | list | join(' or ') }} {{ host_statuses | map('regex_replace', '^(.*)$', 'status=\\1') | list | join(' or ') }}"
       check_mode: "no"
       register: host_info
 


### PR DESCRIPTION
When ansible-runner sends to this role variables it sends as extra_vars and with extra escaping.
This PR with https://gerrit.ovirt.org/#/c/107179/ fixes cluster upgrade for engine 4.4.
issues
- `host_names` were sent as a string and the variable `host_names` cannot be overwritten
- `cluster_name` had extra escaping which created an issue with searching of the host.

@machacekondra @mwperina 